### PR TITLE
accept parameter as it instead of converting it to array

### DIFF
--- a/lib/phonegap-api/base.rb
+++ b/lib/phonegap-api/base.rb
@@ -8,7 +8,7 @@ module Phonegap
     follow_redirects false
     format :json
 
-    def initialize(*auth)
+    def initialize(auth)
       if auth != []
         @auth = {:basic_auth => auth}
       else


### PR DESCRIPTION
I am coding ruby in my Mac OS ruby 1.8.7 and I get the error below when create the Connection object by

conn = Phonegap::Connection.new(:username => '....', :password =>'....')

/Library/Ruby/Gems/1.8/gems/httparty-0.11.0/lib/httparty/request.rb:241:in `validate': :basic_auth must be a hash (ArgumentError)
    from /Library/Ruby/Gems/1.8/gems/httparty-0.11.0/lib/httparty/request.rb:88:in`perform'
    from /Library/Ruby/Gems/1.8/gems/httparty-0.11.0/lib/httparty.rb:461:in `perform_request'
    from /Library/Ruby/Gems/1.8/gems/httparty-0.11.0/lib/httparty.rb:398:in`get'
    from /Library/Ruby/Gems/1.8/gems/phonegap-api-1.2.0/lib/phonegap-api/base.rb:21:in `get'
    from /Library/Ruby/Gems/1.8/gems/phonegap-api-1.2.0/lib/phonegap-api/read.rb:8:in`apps'

This pull request will fix it by accepting the argument as it instead of converting it an array.
